### PR TITLE
name changes related to CMS HOOK and callers.

### DIFF
--- a/cms/src/hooks/cms_hook.e
+++ b/cms/src/hooks/cms_hook.e
@@ -1,5 +1,7 @@
 note
-	description: "Marker interface"
+	description: "[
+			Marker interface for CMS Hook
+		]"
 	date: "$Date$"
 	revision: "$Revision$"
 

--- a/cms/src/hooks/cms_hook_block.e
+++ b/cms/src/hooks/cms_hook_block.e
@@ -1,8 +1,7 @@
 note
 	description: "Summary description for {CMS_HOOK_BLOCK}."
-	author: ""
-	date: "$Date: 2014-08-28 08:21:49 -0300 (ju. 28 de ago. de 2014) $"
-	revision: "$Revision: 95708 $"
+	date: "$Date$"
+	revision: "$Revision$"
 
 deferred class
 	CMS_HOOK_BLOCK

--- a/cms/src/hooks/cms_hook_form_alter.e
+++ b/cms/src/hooks/cms_hook_form_alter.e
@@ -1,6 +1,8 @@
 note
-	description: "Describe how to alter a form before it's rendered"
-	date: "$Date: 2014-08-28 08:21:49 -0300 (ju. 28 de ago. de 2014) $"
+	description: "[
+			Hook providing a way to alter a form.
+		]"
+	date: "$Date$"
 
 deferred class
 	CMS_HOOK_FORM_ALTER
@@ -11,6 +13,8 @@ inherit
 feature -- Hook
 
 	form_alter (a_form: CMS_FORM; a_form_data: detachable WSF_FORM_DATA; a_response: CMS_RESPONSE)
+			-- Hook execution on form `a_form' and its associated data `a_form_data',
+			-- for related response `a_response'.
 		deferred
 		end
 

--- a/cms/src/hooks/cms_hook_menu_alter.e
+++ b/cms/src/hooks/cms_hook_menu_alter.e
@@ -1,6 +1,8 @@
 note
-	description: "Describe how to alter a menu before it's rendered."
-	date: "$Date: 2014-08-28 08:21:49 -0300 (ju. 28 de ago. de 2014) $"
+	description: "[
+			Hook providing a way to alter a menu
+		]"
+	date: "$Date$"
 
 deferred class
 	CMS_HOOK_MENU_ALTER
@@ -10,7 +12,9 @@ inherit
 
 feature -- Hook
 
-	menu_alter (a_menu_system: CMS_MENU_SYSTEM; a_response: CMS_RESPONSE)
+	menu_alter (a_menu: CMS_MENU; a_response: CMS_RESPONSE)
+			-- Hook execution on menu `a_menu'
+			-- for related response `a_response'.
 		deferred
 		end
 

--- a/cms/src/hooks/cms_hook_menu_system_alter.e
+++ b/cms/src/hooks/cms_hook_menu_system_alter.e
@@ -1,0 +1,21 @@
+note
+	description: "[
+			Hook providing a way to alter the CMS menu system.
+		]"
+	date: "$Date$"
+
+deferred class
+	CMS_HOOK_MENU_SYSTEM_ALTER
+
+inherit
+	CMS_HOOK
+
+feature -- Hook
+
+	menu_system_alter (a_menu_system: CMS_MENU_SYSTEM; a_response: CMS_RESPONSE)
+			-- Hook execution on collection of menu contained by `a_menu_system'
+			-- for related response `a_response'.
+		deferred
+		end
+
+end

--- a/cms/src/hooks/cms_hook_value_table_alter.e
+++ b/cms/src/hooks/cms_hook_value_table_alter.e
@@ -1,20 +1,22 @@
 note
-	description: "Describe how to alter generic values before they are rendered."
-	date: "$Date: 2014-10-23 08:30:11 -0300 (ju. 23 de oct. de 2014) $"
-	revision: "$Revision: 95980 $"
+	description: "[
+			Hook providing a way to alter the value table for a response.
+		]"
+	date: "$Date$"
+	revision: "$Revision$"
 
 deferred class
-	CMS_HOOK_VALUE_ALTER
+	CMS_HOOK_VALUE_TABLE_ALTER
 
 inherit
-
 	CMS_HOOK
 
 feature -- Hook
 
-	value_alter (a_value: CMS_VALUE_TABLE; a_response: CMS_RESPONSE)
+	value_table_alter (a_value: CMS_VALUE_TABLE; a_response: CMS_RESPONSE)
 		deferred
 		end
+
 note
 	copyright: "2011-2014, Jocelyn Fiat, Eiffel Software and others"
 	license: "Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"

--- a/cms/src/kernel/content/cms_value_table.e
+++ b/cms/src/kernel/content/cms_value_table.e
@@ -1,7 +1,10 @@
 note
-	description: "Summary description for {CMS_VALUE_TABLE}."
-	date: "$Date: 2014-10-23 08:30:11 -0300 (ju. 23 de oct. de 2014) $"
-	revision: "$Revision: 95980 $"
+	description: "[
+			Object containing a collection of values.
+			It is typically used by `{CMS_RESPONSE}.values' .
+		]"
+	date: "$Date$"
+	revision: "$Revision$"
 
 class
 	CMS_VALUE_TABLE

--- a/cms/src/kernel/form/cms_form.e
+++ b/cms/src/kernel/form/cms_form.e
@@ -19,7 +19,7 @@ feature -- Basic operation
 
 	prepare (a_response: CMS_RESPONSE)
 		do
-			a_response.call_form_alter_hooks (Current, Void)
+			a_response.invoke_form_alter (Current, Void)
 		end
 
 	process (a_response: CMS_RESPONSE)
@@ -29,7 +29,7 @@ feature -- Basic operation
 
 	on_prepared (a_response: CMS_RESPONSE; fd: WSF_FORM_DATA)
 		do
-			a_response.call_form_alter_hooks (Current, fd)
+			a_response.invoke_form_alter (Current, fd)
 		end
 
 	on_processed (a_response: CMS_RESPONSE; fd: WSF_FORM_DATA)

--- a/cms/src/kernel/link/cms_menu_system.e
+++ b/cms/src/kernel/link/cms_menu_system.e
@@ -1,7 +1,9 @@
 note
-	description: "Describe the navigation menus."
-	date: "$Date: 2014-08-28 08:21:49 -0300 (ju. 28 de ago. de 2014) $"
-	revision: "$Revision: 95708 $"
+	description: "[
+			Menu associated with CMS system.
+		]"
+	date: "$Date$"
+	revision: "$Revision$"
 
 class
 	CMS_MENU_SYSTEM
@@ -20,15 +22,17 @@ feature {NONE} -- Initialization
 		do
 			to_implement ("Refactor, take the info from a Database or Configuration file.")
 			create items.make (5)
-			force (create {CMS_MENU}.make ("primary", 3)) -- primary menu
-			force (create {CMS_MENU}.make_with_title ("management", "Management", 3)) -- secondary in admin view.
-			force (create {CMS_MENU}.make_with_title ("secondary", "Navigation", 3)) -- secondary
-			force (create {CMS_MENU}.make_with_title ("user", "User", 3)) -- first_side_bar
+			force (create {CMS_MENU}.make ("primary", 3))
+			force (create {CMS_MENU}.make_with_title ("management", "Management", 3))
+			force (create {CMS_MENU}.make_with_title ("secondary", "Navigation", 3))
+			force (create {CMS_MENU}.make_with_title ("user", "User", 3))
 		end
 
 feature -- Access
 
 	item (n: like {CMS_MENU}.name): CMS_MENU
+			-- Menu associated with name `n',
+			-- if none, it is created.
 		local
 			m: detachable CMS_MENU
 		do
@@ -80,6 +84,7 @@ feature -- Access
 feature -- Change
 
 	force (m: CMS_MENU)
+			-- Add menu `m'.
 		do
 			items.force (m, m.name)
 		end
@@ -94,7 +99,6 @@ feature -- Access
 
 feature {NONE} -- Implementation
 
-	items: HASH_TABLE [CMS_MENU, like {CMS_MENU}.name]
---	items: ARRAYED_LIST [CMS_MENU]
+	items: STRING_TABLE [CMS_MENU]
 
 end

--- a/cms/src/modules/node/node_module.e
+++ b/cms/src/modules/node/node_module.e
@@ -13,7 +13,7 @@ inherit
 			register_hooks
 		end
 
-	CMS_HOOK_MENU_ALTER
+	CMS_HOOK_MENU_SYSTEM_ALTER
 
 	CMS_HOOK_BLOCK
 
@@ -128,8 +128,8 @@ feature -- Hooks
 
 	register_hooks (a_response: CMS_RESPONSE)
 		do
-			a_response.add_menu_alter_hook (Current)
-			a_response.add_block_hook (Current)
+			a_response.subscribe_to_menu_system_alter_hook (Current)
+			a_response.subscribe_to_block_hook (Current)
 		end
 
 	block_list: ITERABLE [like {CMS_BLOCK}.name]
@@ -145,7 +145,7 @@ feature -- Hooks
 --			a_response.add_block (b, "sidebar_second")
 		end
 
-	menu_alter (a_menu_system: CMS_MENU_SYSTEM; a_response: CMS_RESPONSE)
+	menu_system_alter (a_menu_system: CMS_MENU_SYSTEM; a_response: CMS_RESPONSE)
 		local
 			lnk: CMS_LOCAL_LINK
 --			perms: detachable ARRAYED_LIST [READABLE_STRING_8]

--- a/cms/src/service/response/cms_response.e
+++ b/cms/src/service/response/cms_response.e
@@ -368,7 +368,7 @@ feature -- Blocks
 				add_block (l_block, "footer")
 			end
 
-			hook_block_view
+			invoke_block
 		end
 
 	primary_menu_block: detachable CMS_MENU_BLOCK
@@ -478,36 +478,65 @@ feature -- Blocks
 
 feature -- Hook: value alter
 
-	add_value_alter_hook (h: like value_alter_hooks.item)
+	subscribe_to_value_table_alter_hook (h: like value_table_alter_hooks.item)
 		local
-			lst: like value_alter_hooks
+			lst: like value_table_alter_hooks
 		do
-			lst := value_alter_hooks
+			lst := value_table_alter_hooks
 			if lst = Void then
 				create lst.make (1)
-				value_alter_hooks := lst
+				value_table_alter_hooks := lst
 			end
 			if not lst.has (h) then
 				lst.force (h)
 			end
 		end
 
-	value_alter_hooks: detachable ARRAYED_LIST [CMS_HOOK_VALUE_ALTER]
+	value_table_alter_hooks: detachable ARRAYED_LIST [CMS_HOOK_VALUE_TABLE_ALTER]
 
-	call_value_alter_hooks (m: CMS_VALUE_TABLE)
+	invoke_value_table_alter (m: CMS_VALUE_TABLE)
 		do
-			if attached value_alter_hooks as lst then
+			if attached value_table_alter_hooks as lst then
 				across
 					lst as c
 				loop
-					c.item.value_alter (m, Current)
+					c.item.value_table_alter (m, Current)
+				end
+			end
+		end
+
+feature -- Hook: menu_system_alter
+
+	subscribe_to_menu_system_alter_hook (h: like menu_system_alter_hooks.item)
+		local
+			lst: like menu_system_alter_hooks
+		do
+			lst := menu_system_alter_hooks
+			if lst = Void then
+				create lst.make (1)
+				menu_system_alter_hooks := lst
+			end
+			if not lst.has (h) then
+				lst.force (h)
+			end
+		end
+
+	menu_system_alter_hooks: detachable ARRAYED_LIST [CMS_HOOK_MENU_SYSTEM_ALTER]
+
+	invoke_menu_system_alter (m: CMS_MENU_SYSTEM )
+		do
+			if attached menu_system_alter_hooks as lst then
+				across
+					lst as c
+				loop
+					c.item.menu_system_alter (m, Current)
 				end
 			end
 		end
 
 feature -- Hook: menu_alter
 
-	add_menu_alter_hook (h: like menu_alter_hooks.item)
+	subscribe_to_menu_alter_hook (h: like menu_alter_hooks.item)
 		local
 			lst: like menu_alter_hooks
 		do
@@ -523,7 +552,7 @@ feature -- Hook: menu_alter
 
 	menu_alter_hooks: detachable ARRAYED_LIST [CMS_HOOK_MENU_ALTER]
 
-	call_menu_alter_hooks (m: CMS_MENU_SYSTEM )
+	invoke_menu_alter (m: CMS_MENU)
 		do
 			if attached menu_alter_hooks as lst then
 				across
@@ -536,7 +565,7 @@ feature -- Hook: menu_alter
 
 feature -- Hook: form_alter
 
-	add_form_alter_hook (h: like form_alter_hooks.item)
+	subscribe_to_form_alter_hook (h: like form_alter_hooks.item)
 		local
 			lst: like form_alter_hooks
 		do
@@ -552,7 +581,7 @@ feature -- Hook: form_alter
 
 	form_alter_hooks: detachable ARRAYED_LIST [CMS_HOOK_FORM_ALTER]
 
-	call_form_alter_hooks (f: CMS_FORM; a_form_data: detachable WSF_FORM_DATA; )
+	invoke_form_alter (f: CMS_FORM; a_form_data: detachable WSF_FORM_DATA)
 		do
 			if attached form_alter_hooks as lst then
 				across
@@ -565,7 +594,7 @@ feature -- Hook: form_alter
 
 feature -- Hook: block		
 
-	add_block_hook (h: like block_hooks.item)
+	subscribe_to_block_hook (h: CMS_HOOK_BLOCK)
 		local
 			lst: like block_hooks
 		do
@@ -581,7 +610,7 @@ feature -- Hook: block
 
 	block_hooks: detachable ARRAYED_LIST [CMS_HOOK_BLOCK]
 
-	hook_block_view
+	invoke_block
 		do
 			if attached block_hooks as lst then
 				across
@@ -595,7 +624,6 @@ feature -- Hook: block
 				end
 			end
 		end
-
 
 feature -- Menu: change
 
@@ -723,7 +751,7 @@ feature -- Generation
 		do
 				-- Menu
 			add_to_primary_menu (create {CMS_LOCAL_LINK}.make ("Home", "/"))
-			call_menu_alter_hooks (menu_system)
+			invoke_menu_system_alter (menu_system)
 			prepare_menu_system (menu_system)
 
 				-- Blocks
@@ -745,7 +773,7 @@ feature -- Generation
 			custom_prepare (page)
 
 				-- Cms values
-			call_value_alter_hooks (values)
+			invoke_value_table_alter (values)
 
 				-- Predefined values
 			page.register_variable (page, "page") -- DO NOT REMOVE

--- a/examples/roc_api/modules/demo/cms_demo_module.e
+++ b/examples/roc_api/modules/demo/cms_demo_module.e
@@ -13,7 +13,7 @@ inherit
 			register_hooks
 		end
 
-	CMS_HOOK_MENU_ALTER
+	CMS_HOOK_MENU_SYSTEM_ALTER
 
 	CMS_HOOK_BLOCK
 
@@ -45,8 +45,8 @@ feature -- Hooks
 
 	register_hooks (a_response: CMS_RESPONSE)
 		do
-			a_response.add_menu_alter_hook (Current)
-			a_response.add_block_hook (Current)
+			a_response.subscribe_to_menu_system_alter_hook (Current)
+			a_response.subscribe_to_block_hook (Current)
 		end
 
 	block_list: ITERABLE [like {CMS_BLOCK}.name]
@@ -56,7 +56,7 @@ feature -- Hooks
 
 	get_block_view (a_block_id: READABLE_STRING_8; a_response: CMS_RESPONSE)
 		local
-			b: CMS_CONTENT_BLOCK
+--			b: CMS_CONTENT_BLOCK
 			mb: CMS_MENU_BLOCK
 			m: CMS_MENU
 			lnk: CMS_LOCAL_LINK
@@ -74,7 +74,7 @@ feature -- Hooks
 			end
 		end
 
-	menu_alter (a_menu_system: CMS_MENU_SYSTEM; a_response: CMS_RESPONSE)
+	menu_system_alter (a_menu_system: CMS_MENU_SYSTEM; a_response: CMS_RESPONSE)
 		local
 			lnk: CMS_LOCAL_LINK
 --			perms: detachable ARRAYED_LIST [READABLE_STRING_8]


### PR DESCRIPTION
Renamed CMS_RESPONSE.add_..hook  with subscribe_to_..._hook
Renamed CMS_RESPONSE.call_..hook  with invoke_..._hook
Renamed CMS_HOOK_VALUE_ALTER as CMS_HOOK_VALUE_TABLE_ALTER
Renamed CMS_HOOK_MENU_ALTER as CMS_HOOK_MENU_SYSTEM_ALTER
Added new CMS_HOOK_MENU_ALTER that acts on CMS_MENU object.

Cosmetic, comments.
